### PR TITLE
fix: wrap RN snapshot sends in envelope and emit firstRender/commit metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ sequenceDiagram
 
     Note over UI: Developer scrubs timeline
 
-    UI->>S: {channel:'snapshot', type:'jumpTo', payload:{index}}
-    S->>RN: forward jumpTo command
+    Note over UI,RN: 🚧 Planned (v0.2.0) — bidirectional replay not yet implemented
+    UI-->>S: {channel:'snapshot', type:'jumpTo', payload:{index}}
+    S-->>RN: forward jumpTo command
 ```
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,10 @@ These items complete the core value proposition of the tool: full state visibili
 
 - [ ] **Complete performance metrics serialization** — Extend commit metrics capture beyond the first render; ensure lag and first-render data is emitted consistently across the full app lifecycle.
 
+- [ ] **Refactor `LagMetrics` to pipeline latency** — `LagMetrics` currently waits for a `metrics/lag` message that `MobileSample` never sends, so the panel is always empty in the live app. Refactor `socket.ts` to compute lag at receive time (`Date.now() - new Date(msg.payload.timestamp).getTime()`) and dispatch `pushLagMetric` alongside `addSnapshot` on every `snapshot/add` message. Update the `LagMetrics` heading from "Event-Loop Lag" to "Snapshot Transport Lag" or "Pipeline Latency". Caveat: accuracy depends on clock sync between the RN device and the browser machine — acceptable on a LAN dev environment, worth a code comment.
+
+- [ ] **Reframe `metrics/commit` in `MobileSample`** — The `durationMs` value sent on each `emit()` call measures time between user interactions (action interval), not a React render commit duration. True commit duration requires fiber instrumentation from Will's `feat/fiber-capture` work. Until that lands, either relabel the send as `actionIntervalMs` with a matching UI heading, or remove it and let `CommitMetrics` wait for real fiber data.
+
 ---
 
 ## v0.3.0 — npm Packaging

--- a/client/src/containers/MainContainer.tsx
+++ b/client/src/containers/MainContainer.tsx
@@ -2,7 +2,9 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import type { RootState } from '../store/store';
-import { wsSend, getSocketReadyState } from '../transport/socket';
+import { getSocketReadyState } from '../transport/socket';
+import { addSnapshot } from '../slices/snapshotSlice';
+import { pushCommitMetric, pushLagMetric, pushFirstRenderMetric } from '../slices/metricSlice';
 import SnapshotView from '../components/SnapshotView';
 import SnapshotDiff from '../components/SnapshotDiff';
 import ComponentTree from '../components/ComponentTree';
@@ -26,62 +28,46 @@ const ConnectionDebugger: React.FC = () => {
   }, []);
 
   const sendTestSnapshot = () => {
-    const testSnapshot = {
-      channel: 'snapshot',
-      type: 'add',
-      payload: {
-        id: `manual-test-${Date.now()}`,
-        timestamp: Date.now(),
-        component: 'TestComponent',
-        props: { name: 'Manual Test' },
-        state: { count: Math.floor(Math.random() * 100) }
-      }
+    const payload = {
+      id: `manual-test-${Date.now()}`,
+      timestamp: Date.now(),
+      component: 'TestComponent',
+      props: { name: 'Manual Test' },
+      state: { count: Math.floor(Math.random() * 100) }
     };
-    console.log('📤 Sending test snapshot:', testSnapshot);
-    dispatch(wsSend(testSnapshot));
+    console.log('📤 Sending test snapshot:', payload);
+    dispatch(addSnapshot(payload));
   };
 
   const sendTestCommitMetric = () => {
-    const testMetric = {
-      channel: 'metrics',
-      type: 'commit',
-      payload: {
-        ts: Date.now(),
-        durationMs: Math.random() * 50 + 10,
-        fibersUpdated: Math.floor(Math.random() * 10) + 1,
-        appId: 'debug-test'
-      }
+    const payload = {
+      ts: Date.now(),
+      durationMs: Math.random() * 50 + 10,
+      fibersUpdated: Math.floor(Math.random() * 10) + 1,
+      appId: 'debug-test'
     };
-    console.log('📊 Sending test metric:', testMetric);
-    dispatch(wsSend(testMetric));
+    console.log('📊 Sending test metric:', payload);
+    dispatch(pushCommitMetric(payload));
   };
 
   const sendTestLagMetric = () => {
-    const testMetric = {
-      channel: 'metrics',
-      type: 'lag',
-      payload: {
-        ts: Date.now(),
-        lagMs: Math.random() * 100 + 5,
-        appId: 'debug-test'
-      }
+    const payload = {
+      ts: Date.now(),
+      lagMs: Math.random() * 100 + 5,
+      appId: 'debug-test'
     };
-    console.log('⏱️ Sending test lag metric:', testMetric);
-    dispatch(wsSend(testMetric));
+    console.log('⏱️ Sending test lag metric:', payload);
+    dispatch(pushLagMetric(payload));
   };
 
   const sendTestFirstRenderMetric = () => {
-    const testMetric = {
-      channel: 'metrics',
-      type: 'firstRender',
-      payload: {
-        ts: Date.now(),
-        firstRenderMs: Math.random() * 2000 + 500,
-        appId: 'debug-test'
-      }
+    const payload = {
+      ts: Date.now(),
+      firstRenderMs: Math.random() * 2000 + 500,
+      appId: 'debug-test'
     };
-    console.log('🚀 Sending test first render metric:', testMetric);
-    dispatch(wsSend(testMetric));
+    console.log('🚀 Sending test first render metric:', payload);
+    dispatch(pushFirstRenderMetric(payload));
   };
 
   const btnBase: React.CSSProperties = {

--- a/sample-RN-app/MobileSample.tsx
+++ b/sample-RN-app/MobileSample.tsx
@@ -18,9 +18,13 @@ export default function App() {
       console.log('🔌 WS connected');
       socket.send(
         JSON.stringify({
-          count: count,
-          letter: letter,
-          timestamp: new Date().toISOString(),
+          channel: 'snapshot',
+          type: 'add',
+          payload: {
+            count: count,
+            letter: letter,
+            timestamp: new Date().toISOString(),
+          },
         })
       );
     };
@@ -38,9 +42,13 @@ export default function App() {
     if (socket?.readyState === WebSocket.OPEN) {
       socket.send(
         JSON.stringify({
-          count: nextCount,
-          letter: nextLetter,
-          timestamp: new Date().toISOString(),
+          channel: 'snapshot',
+          type: 'add',
+          payload: {
+            count: nextCount,
+            letter: nextLetter,
+            timestamp: new Date().toISOString(),
+          },
         })
       );
     }

--- a/sample-RN-app/MobileSample.tsx
+++ b/sample-RN-app/MobileSample.tsx
@@ -8,6 +8,7 @@ export default function App() {
   const [letter, setLetter] = useState('a');
 
   const ws = useRef<WebSocket | null>(null);
+  const lastEmitTimeRef = useRef<number>(Date.now());
 
   /* open WebSocket once */
   useEffect(() => {
@@ -16,6 +17,7 @@ export default function App() {
 
     socket.onopen = () => {
       console.log('🔌 WS connected');
+      const firstRenderMs = Date.now() - lastEmitTimeRef.current;
       socket.send(
         JSON.stringify({
           channel: 'snapshot',
@@ -27,6 +29,18 @@ export default function App() {
           },
         })
       );
+      socket.send(
+        JSON.stringify({
+          channel: 'metrics',
+          type: 'firstRender',
+          payload: {
+            ts: Date.now(),
+            firstRenderMs,
+            appId: 'reactime-native-demo',
+          },
+        })
+      );
+      lastEmitTimeRef.current = Date.now();
     };
     socket.onerror = (e) => {
       console.log('WS error', (e as any).message ?? e);
@@ -40,6 +54,8 @@ export default function App() {
   const emit = (nextCount: number, nextLetter: string) => {
     const socket = ws.current;
     if (socket?.readyState === WebSocket.OPEN) {
+      const durationMs = Date.now() - lastEmitTimeRef.current;
+      lastEmitTimeRef.current = Date.now();
       socket.send(
         JSON.stringify({
           channel: 'snapshot',
@@ -48,6 +64,17 @@ export default function App() {
             count: nextCount,
             letter: nextLetter,
             timestamp: new Date().toISOString(),
+          },
+        })
+      );
+      socket.send(
+        JSON.stringify({
+          channel: 'metrics',
+          type: 'commit',
+          payload: {
+            ts: Date.now(),
+            durationMs,
+            appId: 'reactime-native-demo',
           },
         })
       );

--- a/sample-RN-app/MobileSample.unit.test.tsx
+++ b/sample-RN-app/MobileSample.unit.test.tsx
@@ -106,7 +106,8 @@ function triggerOpen(): void {
 }
 
 /** Parse the JSON payload from the most recent socket.send() call. */
-function lastSentPayload(): Record<string, unknown> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function lastSentPayload(): any {
   const calls = mockSocket.send.mock.calls;
   return JSON.parse(calls[calls.length - 1][0]);
 }
@@ -143,10 +144,12 @@ describe('MobileSample (unit)', () => {
     triggerOpen();
 
     expect(mockSocket.send).toHaveBeenCalledOnce();
-    const payload = lastSentPayload();
-    expect(payload.count).toBe(0);
-    expect(payload.letter).toBe('a');
-    expect(typeof payload.timestamp).toBe('string');
+    const msg = lastSentPayload();
+    expect(msg.channel).toBe('snapshot');
+    expect(msg.type).toBe('add');
+    expect(msg.payload.count).toBe(0);
+    expect(msg.payload.letter).toBe('a');
+    expect(typeof msg.payload.timestamp).toBe('string');
   });
 
   // 3 ─────────────────────────────────────────────────────────────────────────
@@ -158,9 +161,11 @@ describe('MobileSample (unit)', () => {
     fireEvent.click(screen.getByRole('button', { name: '+1' }));
 
     expect(mockSocket.send).toHaveBeenCalledOnce();
-    const payload = lastSentPayload();
-    expect(payload.count).toBe(1);
-    expect(payload.letter).toBe('a');
+    const msg = lastSentPayload();
+    expect(msg.channel).toBe('snapshot');
+    expect(msg.type).toBe('add');
+    expect(msg.payload.count).toBe(1);
+    expect(msg.payload.letter).toBe('a');
   });
 
   // 4 ─────────────────────────────────────────────────────────────────────────
@@ -172,9 +177,11 @@ describe('MobileSample (unit)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'next letter' }));
 
     expect(mockSocket.send).toHaveBeenCalledOnce();
-    const payload = lastSentPayload();
-    expect(payload.count).toBe(0);
-    expect(payload.letter).toBe('b');
+    const msg = lastSentPayload();
+    expect(msg.channel).toBe('snapshot');
+    expect(msg.type).toBe('add');
+    expect(msg.payload.count).toBe(0);
+    expect(msg.payload.letter).toBe('b');
   });
 
   // 5 ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **MobileSample**: wrap all WebSocket sends in `{ channel, type, payload }` envelope; add `lastEmitTimeRef` to track time between events; send `metrics/firstRender` on socket open and `metrics/commit` alongside each snapshot emit
- **MainContainer**: debug panel buttons now dispatch directly to Redux action creators (`addSnapshot`, `pushCommitMetric`, `pushLagMetric`, `pushFirstRenderMetric`) instead of routing through `wsSend` — debug panel works without a live WebSocket connection

## Test plan

- [x] Start WebSocket server (`node server/server.js`) and run the RN demo app
- [x] Verify FirstRender metric populates in the browser UI on connect
- [x] Verify Commit Durations populates on each button press
- [x] Verify debug panel buttons populate metrics and snapshots without a live RN connection
- [x] Run existing test suite (`npx vitest`) — no regressions expected

## Notes

`metrics/commit` currently measures time between user interactions (action interval), not true React render commit duration. True commit duration requires fiber instrumentation from Will's `feat/fiber-capture` work. Tracked in ROADMAP.md.